### PR TITLE
Improvements in clarity and consistency

### DIFF
--- a/Assessments/Assessment Approach.md
+++ b/Assessments/Assessment Approach.md
@@ -1,18 +1,19 @@
 
 With a goal to determine the Government of Canada's (GC) preferred open source platforms, the following steps are being taken to ensure an open and collaborative process.
 
-**1. Design assessment criteria based on:**
+**1. Assessment criteria based upon:**
 
 - Existing Government of Canada policies, standards, and guidelines
 - Open standards and best practices
 - Domain-specific industry standards and best practices
-- Sample criteria template can be found [here] (https://github.com/canada-ca/Open_First_Whitepaper/blob/master/Assessments/Template.md)
+
+Sample criteria can be found in the [assessment template](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/Assessments/Template.md)
 
 **2. Collaborative assessment against criteria:**
 
 - Leveraging open source knowledge from domain experts to complete assessments
-- GC Configurations to be assessed will be contributed by the community based on existing and emerging tools
-- If you would like to assess a tool that you don't see listed, [make a pull request] (https://help.github.com/articles/creating-a-pull-request/) for a new file, and use the [template](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/Assessments/Template.md)
+- GC Configurations to be assessed will be contributed by the community based on existing and emerging platforms
+- If you would like to assess a platform that you don't see listed, [make a pull request](https://help.github.com/articles/creating-a-pull-request/) to add a new assessment file using the [assessment template](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/Assessments/Template.md)
 
 **3. Consult with open source community:**
 
@@ -22,6 +23,6 @@ With a goal to determine the Government of Canada's (GC) preferred open source p
 
 **4. GC Governance:**
 
-- Following the completion of the collaborative design process for assessment, consultations, recommendations for preferred open source platforms will be provided to the GC's Enterprise Architecture Review Board (EARB).
-- If recommendation for preferred tool is approved by EARB, it will be added to the list of [Preferred Open Platforms](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/9_Preferred_Open_Platforms.md).
+- Following the completion of the collaborative process for assessment and consultations, recommendations for preferred open source platforms will be provided to the GC's Enterprise Architecture Review Board (EARB) for review.
+- If the recommendation for preferred platform is approved by EARB, it will be added to the list of [Preferred Open Platforms](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/9_Preferred_Open_Platforms.md).
 - Internal governance will continue to adopt preferred platforms within necessary GC Standards and Guidelines.


### PR DESCRIPTION
- Changed "tools" to "platforms" to be consistent throughout (since was alternating between platforms and tools). Another option could be to use "tools" instead of "platforms" (should be consistent either way).
- Moved the link for the Sample criteria template outside of the bulleted list in the first section since the assessment criteria is not based upon the template. Also made the text clearer and easier to read (avoiding the "can be found here" part).
- Change "template" references to "assessment template" to be clearer about the intent.
- Removed "design" and changed "," to " and" in the first bullet of the fourth section to make it easier to read.
- Removed spaces between square brackets and round brackets when creating links (since a space results in no long being created).
- Removed "Design" from the heading of the first section to make the meaning clearer (since "Design" design can have more than one meaning in that context for instance it could be a verb or a noun).