### PR TITLE
chore: update link to the renamed Open Resource

### DIFF
--- a/Assessments/Assessment Approach.md
+++ b/Assessments/Assessment Approach.md
@@ -7,13 +7,13 @@ With a goal to determine the Government of Canada's (GC) preferred open source p
 - Open standards and best practices
 - Domain-specific industry standards and best practices
 
-Sample criteria can be found in the [assessment template](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/Assessments/Template.md)
+Sample criteria can be found in the [assessment template](Template.md)
 
 **2. Collaborative assessment against criteria:**
 
 - Leveraging open source knowledge from domain experts to complete assessments
 - GC Configurations to be assessed will be contributed by the community based on existing and emerging platforms
-- If you would like to assess a platform that you don't see listed, [make a pull request](https://help.github.com/articles/creating-a-pull-request/) to add a new assessment file using the [assessment template](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/Assessments/Template.md)
+- If you would like to assess a platform that you don't see listed, [make a pull request](https://help.github.com/articles/creating-a-pull-request/) to add a new assessment file using the [assessment template](Template.md)
 
 **3. Consult with open source community:**
 
@@ -24,5 +24,5 @@ Sample criteria can be found in the [assessment template](https://github.com/can
 **4. GC Governance:**
 
 - Following the completion of the collaborative process for assessment and consultations, recommendations for preferred open source platforms will be provided to the GC's Enterprise Architecture Review Board (EARB) for review.
-- If the recommendation for preferred platform is approved by EARB, it will be added to the list of [Preferred Open Platforms](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/9_Preferred_Open_Platforms.md).
+- If the recommendation for preferred platform is approved by EARB, it will be added to the list on the [Open Resource Exchange](../9_Open_Resource_Exchange.md).
 - Internal governance will continue to adopt preferred platforms within necessary GC Standards and Guidelines.


### PR DESCRIPTION
These might end up getting pulled out, but the old "Prefered OSS" link is broken right now.
Also make absolute links to relative so they should get checked by the linter.