### PR TITLE
Fixed README and top navigation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ We want to learn as much as possible from Canadians, our partners, academics and
 
 ## Table of Content
 
-1. [Introduction](1_Introduction.md)
-2. [Open Standards](2_Open_Standards.md)
-3. [Open Source Software](3_Open_Source_Software.md)
-4. [Open Source Code](4_Open_Source_Code.md)
-5. [Open Markets](5_Open_Markets.md)
-6. [Open Culture](6_Open_Culture.md)
-7. [Next Steps](7_Next_Steps.md)
-8. [Definitions](8_Definitions.md)
+1. [Introduction](en/1_Introduction.md)
+2. [Open Standards](en/2_Open_Standards.md)
+3. [Open Source Software](en/3_Open_Source_Software.md)
+4. [Open Source Code](en/4_Open_Source_Code.md)
+5. [Open Markets](en/5_Open_Markets.md)
+6. [Open Culture](en/6_Open_Culture.md)
+7. [Next Steps](en/7_Next_Steps.md)
+8. [Definitions](en/8_Definitions.md)
 
 ## How to Contribute
 
@@ -41,14 +41,14 @@ Nous tenons à en apprendre autant que possible de la part des Canadiens, de nos
 
 ## Table des matières
 
-1. [Introduction](1_Introduction.md)
-2. [Normes ouvertes](2_Open_Standards.md)
-3. [Logiciels libres (open source)](3_Open_Source_Software.md)
-4. [Code source ouvert](4_Open_Source_Code.md)
-5. [Marchés ouverts](5_Open_Markets.md)
-6. [Culture ouverte](6_Open_Culture.md)
-7. [Prochaines étapes](7_Next_Steps.md)
-8. [Définitions](8_Definitions.md)
+1. [Introduction](fr/1_Introduction.md)
+2. [Normes ouvertes](fr/2_Normes_ouvertes.md)
+3. [Logiciels libres (open source)](fr/3_Logiciel_libre.md)
+4. [Code source ouvert](fr/4_Code_source_libre.md)
+5. [Marchés ouverts](fr/5_Marchés_ouverts.md)
+6. [Culture ouverte](fr/6_Culture_ouverte.md)
+7. [Prochaines étapes](fr/7_Prochaines_étapes.md)
+8. [Définitions](fr/8_Définitions.md)
 
 ## Comment contribuer
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This whitepaper is being co-developed by many members of the GC open source comm
 
 We want to learn as much as possible from Canadians, our partners, academics and technical experts to help us update GC policies, governance, funding and processes with an open lens.
 
-## Table of Content
+## Table of Contents
 
 1. [Introduction](en/1_Introduction.md)
 2. [Open Standards](en/2_Open_Standards.md)

--- a/en/1_Introduction.md
+++ b/en/1_Introduction.md
@@ -1,4 +1,4 @@
-[Table of Contents](../README.md#table-of-content) | [Next Page: Open Standards »](2_Open_Standards.md)
+[Table of Contents](../README.md#table-of-contents) | [Next Page: Open Standards »](2_Open_Standards.md)
 
 ## Introduction
 

--- a/en/1_Introduction.md
+++ b/en/1_Introduction.md
@@ -1,4 +1,4 @@
-[Table of Content](README.md#table-of-content) | [Next Page: Open Standards »](2_Open_Standards.md)
+[Table of Contents](../README.md#table-of-content) | [Next Page: Open Standards »](2_Open_Standards.md)
 
 ## Introduction
 

--- a/en/2_Open_Standards.md
+++ b/en/2_Open_Standards.md
@@ -1,4 +1,4 @@
-[« Previous Page : Introduction](1_Introduction.md) | [Table of Content](README.md#table-of-content) | [Next Page: Open Source Software »](3_Open_Source_Software.md)
+[« Previous Page : Introduction](1_Introduction.md) | [Table of Contents](README.md#table-of-contents) | [Next Page: Open Source Software »](3_Open_Source_Software.md)
 
 ## Open Standards
 

--- a/en/2_Open_Standards.md
+++ b/en/2_Open_Standards.md
@@ -1,4 +1,4 @@
-[« Previous Page : Introduction](1_Introduction.md) | [Table of Contents](README.md#table-of-contents) | [Next Page: Open Source Software »](3_Open_Source_Software.md)
+[« Previous Page : Introduction](1_Introduction.md) | [Table of Contents](../README.md#table-of-contents) | [Next Page: Open Source Software »](3_Open_Source_Software.md)
 
 ## Open Standards
 

--- a/en/3_Open_Source_Software.md
+++ b/en/3_Open_Source_Software.md
@@ -1,4 +1,4 @@
-[« Previous Page : Open Standards](2_Open_Standards.md) | [Table of Content](README.md#table-of-content) | [Next Page: Open Source Code »](4_Open_Source_Code.md)
+[« Previous Page : Open Standards](2_Open_Standards.md) | [Table of Contents](../README.md#table-of-contents) | [Next Page: Open Source Code »](4_Open_Source_Code.md)
 
 ## Open Source Software
 

--- a/en/4_Open_Source_Code.md
+++ b/en/4_Open_Source_Code.md
@@ -1,4 +1,4 @@
-[« Previous Page : Open Source Software](3_Open_Source_Software.md) | [Table of Content](README.md#table-of-content) | [Next Page: Open Markets »](5_Open_Markets.md)
+[« Previous Page : Open Source Software](3_Open_Source_Software.md) | [Table of Contents](../README.md#table-of-contents) | [Next Page: Open Markets »](5_Open_Markets.md)
 
 ## Open Source Code
 

--- a/en/5_Open_Markets.md
+++ b/en/5_Open_Markets.md
@@ -1,4 +1,4 @@
-[« Previous Page : Open Source Code](4_Open_Source_Code.md) | [Table of Content](README.md#table-of-content) | [Next Page: Open Culture »](6_Open_Culture.md)
+[« Previous Page : Open Source Code](4_Open_Source_Code.md) | [Table of Contents](../README.md#table-of-contents) | [Next Page: Open Culture »](6_Open_Culture.md)
 
 ## Open Markets
 

--- a/en/6_Open_Culture.md
+++ b/en/6_Open_Culture.md
@@ -1,4 +1,4 @@
-[« Previous Page : Open Markets](5_Open_Markets.md) | [Table of Content](README.md#table-of-content) | [Next Page: Next Steps »](7_Next_Steps.md)
+[« Previous Page : Open Markets](5_Open_Markets.md) | [Table of Contents](../README.md#table-of-contents) | [Next Page: Next Steps »](7_Next_Steps.md)
 
 ## Open Culture
 

--- a/en/7_Next_Steps.md
+++ b/en/7_Next_Steps.md
@@ -1,4 +1,4 @@
-[« Previous Page : Open Culture](6_Open_Culture.md) | [Table of Content](README.md#table-of-content) | [Next Page: Definitions »](8_Definitions.md)
+[« Previous Page : Open Culture](6_Open_Culture.md) | [Table of Contents](../README.md#table-of-contents) | [Next Page: Definitions »](8_Definitions.md)
 
 ## Next Steps
 

--- a/en/8_Definitions.md
+++ b/en/8_Definitions.md
@@ -1,4 +1,4 @@
-[« Previous Page : Next Steps](7_Next_Steps.md) | [Table of Content](README.md#table-of-content)
+[« Previous Page : Next Steps](7_Next_Steps.md) | [Table of Contents](README.md#table-of-contents)
 
 ## Definitions
 

--- a/fr/1_Introduction.md
+++ b/fr/1_Introduction.md
@@ -1,4 +1,4 @@
-[Table des matières] (README.md#table-of-content) | [Page suivante : Normes ouvertes »] (2_Open_Standards.md)
+[Table des matières](../README.md#table-des-mati%C3%A8res) | [Page suivante : Normes ouvertes »](2_Normes_ouvertes.md)
 
 ## Introduction
 

--- a/fr/2_Normes_ouvertes.md
+++ b/fr/2_Normes_ouvertes.md
@@ -1,4 +1,4 @@
-[« Previous Page : Introduction](1_Introduction.md) | [Table of Content](README.md#table-of-content) | [Next Page: Open Source Software »](3_Open_Source_Software.md)
+[« Page précédente : Introduction](1_Introduction.md) | [Table des matières](../README.md#table-des-mati%C3%A8res) | [Page suivante : Logiciels libres (open source) »](3_Logiciel_libre.md)
 
 ## Open Standards
 

--- a/fr/3_Logiciel_libre.md
+++ b/fr/3_Logiciel_libre.md
@@ -1,4 +1,4 @@
-[« Previous Page : Open Standards](2_Open_Standards.md) | [Table of Content](README.md#table-of-content) | [Next Page: Open Source Code »](4_Open_Source_Code.md)
+[« Page précédente : Normes ouvertes](2_Normes_ouvertes.md) | [Table des matières](../README.md#table-des-mati%C3%A8res) | [Page suivante : Code source ouvert »](4_Code_source_libre.md)
 
 ## Open Source Software
 

--- a/fr/4_Code_source_libre.md
+++ b/fr/4_Code_source_libre.md
@@ -1,4 +1,4 @@
-[« Page précédente : Logiciels libres (open source)](3_Logiciel_libre.md) | [Table des matières](../README.md#table-des-mati%C3%A8res) | [Page suivante : Marchés ouverts »](5_Marchés_ouverts.md.md)
+[« Page précédente : Logiciels libres (open source)](3_Logiciel_libre.md) | [Table des matières](../README.md#table-des-mati%C3%A8res) | [Page suivante : Marchés ouverts »](5_Marchés_ouverts.md)
 
 ## Open Source Code
 

--- a/fr/4_Code_source_libre.md
+++ b/fr/4_Code_source_libre.md
@@ -1,4 +1,4 @@
-[« Previous Page : Open Source Software](3_Open_Source_Software.md) | [Table of Content](README.md#table-of-content) | [Next Page: Open Markets »](5_Open_Markets.md)
+[« Page précédente : Logiciels libres (open source)](3_Logiciel_libre.md) | [Table des matières](../README.md#table-des-mati%C3%A8res) | [Page suivante : Marchés ouverts »](5_Marchés_ouverts.md.md)
 
 ## Open Source Code
 

--- a/fr/5_Marchés_ouverts.md
+++ b/fr/5_Marchés_ouverts.md
@@ -1,4 +1,4 @@
-[« Previous Page : Open Source Code](4_Open_Source_Code.md) | [Table of Content](README.md#table-of-content) | [Next Page: Open Culture »](6_Open_Culture.md)
+[« Page précédente : Code source ouvert](4_Code_source_libre.md) | [Table des matières](../README.md#table-des-mati%C3%A8res) | [Page suivante : Culture ouverte »](6_Culture_ouverte.md)
 
 ## Open Markets
 

--- a/fr/6_Culture_ouverte.md
+++ b/fr/6_Culture_ouverte.md
@@ -1,4 +1,4 @@
-[« Previous Page : Open Markets](5_Open_Markets.md) | [Table of Content](README.md#table-of-content) | [Next Page: Next Steps »](7_Next_Steps.md)
+[« Page précédente : Marchés ouverts](5_Marchés_ouverts.md) | [Table des matières](../README.md#table-des-mati%C3%A8res) | [Page suivante : Prochaines étapes »](7_Prochaines_étapes.md)
 
 ## Open Culture
 

--- a/fr/7_Prochaines_étapes.md
+++ b/fr/7_Prochaines_étapes.md
@@ -1,3 +1,5 @@
+[« Page précédente : Culture ouverte](6_Culture_ouverte.md) | [Table des matières](../README.md#table-des-mati%C3%A8res) | [Page suivante : Définitions »](8_Définitions.md)
+
 ## Prochaines étapes
 
 ### Réalisations du GC

--- a/fr/8_Définitions.md
+++ b/fr/8_Définitions.md
@@ -1,3 +1,5 @@
+[« Page précédente : Prochaines étapes](7_Prochaines_étapes.md) | [Table des matières](../README.md#table-des-mati%C3%A8res)
+
 ## Définitions
 
 ### Interopérabilité


### PR DESCRIPTION
- README and top navigation links were broken with the recent move to en and fr folders
- Changed "Table of Content" to "Table of Contents"
- Changed top navigation links to French on the French pages 
- Added missing top navigation links on the last two French pages