### PR TITLE
chore: Bump URL lookout timout to 30 seconds

### DIFF
--- a/link-check.js
+++ b/link-check.js
@@ -11,6 +11,7 @@ var chalk = require("chalk");
 var files = glob.sync("**/*.md", {ignore: ["node_modules/**/*.md"]})
 
 var opts = JSON.parse(fs.readFileSync(".markdown-link-check.json"));
+opts.timeout = '30s'
 
 files.forEach(function(file) {
   var markdown = fs.readFileSync(file).toString();


### PR DESCRIPTION
Trying a different thing to see if it works for more of the slow loading links rather than disabling them